### PR TITLE
US45936 change in auto mount script

### DIFF
--- a/is/esb/automount.sh
+++ b/is/esb/automount.sh
@@ -78,7 +78,7 @@ fi
 sudo echo  "[Unit]
 Description=Dell Boomi [atomName]
 After=network.target
-RequiresMountsFor=[installDirMountPoint]
+RequiresMountsFor=/data/boomi/bin
 [Service]
 Type=forking
 User=root


### PR DESCRIPTION
the change is made so that when the instances are restarted it can look for boomi binaries in the mounted file share [storage account]